### PR TITLE
added length and width to store update public info

### DIFF
--- a/Plot/DataAccess/Contexts/StoreContext.cs
+++ b/Plot/DataAccess/Contexts/StoreContext.cs
@@ -69,6 +69,8 @@ public class StoreContext : DbContext, IStoreContext
         parameters.Add("CITY", updateStore.CITY);
         parameters.Add("STATE", updateStore.STATE);
         parameters.Add("ZIP", updateStore.ZIP);
+        parameters.Add("LENGTH", updateStore.LENGTH);
+        parameters.Add("WIDTH", updateStore.WIDTH);
         parameters.Add("BLUEPRINT_IMAGE", updateStore.BLUEPRINT_IMAGE);
 
         return await CreateUpdateDeleteStoredProcedureQuery("Insert_Update_Store", parameters);


### PR DESCRIPTION
I'm literally adding the length and width to the store's update public info endpoint. Literally. I added it to the parameters list sent to the database stored procedure. Literally. Like, literally.