### PR TITLE
28 fix update access allow insert without delete

### DIFF
--- a/Plot/Controllers/UsersController.cs
+++ b/Plot/Controllers/UsersController.cs
@@ -286,4 +286,30 @@ public class UsersController : ControllerBase
 
         return Ok(stores);
     }
+
+    /// <summary>
+    /// Get user by email
+    /// </summary>
+    /// <param name="userEmail">The email of the user</param>
+    /// <returns>UserDTO object</returns>
+    [Authorize]
+    [HttpGet("get-user-by-email/{userEmail}")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<UserDTO>> GetUserByEmail(string userEmail)
+    {
+        Console.WriteLine("User controller getting user by email for " + userEmail);
+        var userDTO = await _userContext.GetUserByEmail(userEmail);
+
+        Console.WriteLine(userDTO.TUID);
+
+        if (userDTO == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(userDTO);
+    }
 }

--- a/Plot/Controllers/UsersController.cs
+++ b/Plot/Controllers/UsersController.cs
@@ -261,6 +261,29 @@ public class UsersController : ControllerBase
             NotFound();
         }
 
-        return Ok();
+        return Ok(stores);
+    }
+
+    /// <summary>
+    /// returns all the stores a user does not work at
+    /// </summary>
+    /// <param name="userId">The id of the user</param>
+    /// <returns>UserDTO object</returns>
+    [Authorize]
+    [HttpGet("stores-not/{userId:int}")]
+    [Produces("application/json")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IEnumerable<Store>>> GetStoresNotForUser(int userId)
+    {
+        var stores = await _userContext.GetStoresNotForUser(userId);
+
+        if (stores == null)
+        {
+            NotFound();
+        }
+
+        return Ok(stores);
     }
 }

--- a/Plot/DataAccess/Contexts/UserContext.cs
+++ b/Plot/DataAccess/Contexts/UserContext.cs
@@ -77,15 +77,12 @@ public class UserContext : DbContext, IUserContext
 
         rowsAffected = await CreateUpdateDeleteStoredProcedureQuery("Delete_All_Access", parameters);
 
-        if (rowsAffected != 0)
+        foreach (int store in updateAccessList.STORE_TUIDS)
         {
-            foreach (int store in updateAccessList.STORE_TUIDS)
-            {
-                parameters = new DynamicParameters();
-                parameters.Add("USER_TUID", updateAccessList.USER_TUID);
-                parameters.Add("STORE_TUID", store); 
-                rowsAffected += await CreateUpdateDeleteStoredProcedureQuery("Insert_Access", parameters);
-            }
+            parameters = new DynamicParameters();
+            parameters.Add("USER_TUID", updateAccessList.USER_TUID);
+            parameters.Add("STORE_TUID", store); 
+            rowsAffected += await CreateUpdateDeleteStoredProcedureQuery("Insert_Access", parameters);
         }
 
         return rowsAffected;

--- a/Plot/DataAccess/Contexts/UserContext.cs
+++ b/Plot/DataAccess/Contexts/UserContext.cs
@@ -46,6 +46,14 @@ public class UserContext : DbContext, IUserContext
         return await GetStoredProcedureQuery<Store>("Select_Users_Store_Access", parameters);
     }
 
+        public async Task<IEnumerable<Store>?> GetStoresNotForUser(int userid)
+    {
+        DynamicParameters parameters = new DynamicParameters();
+        parameters.Add("USER_TUID", userid);
+
+        return await GetStoredProcedureQuery<Store>("Select_Unassigned_User_Stores", parameters);
+    }
+
     public async Task<int> UpdateUserPublicInfo(int userId, UpdatePublicInfoUser user)
     {
         DynamicParameters parameters = new DynamicParameters();

--- a/Plot/DataAccess/Contexts/UserContext.cs
+++ b/Plot/DataAccess/Contexts/UserContext.cs
@@ -38,6 +38,14 @@ public class UserContext : DbContext, IUserContext
         return await GetFirstOrDefaultStoredProcedureQuery<UserDTO>("Select_Users", parameters);
     }
 
+    public async Task<UserDTO?> GetUserByEmail(string userEmail)
+    {
+        DynamicParameters parameters = new DynamicParameters();
+        parameters.Add("EMAIL", userEmail);
+
+        return await GetFirstOrDefaultStoredProcedureQuery<UserDTO>("Select_User_Login", parameters);
+    }
+
     public async Task<IEnumerable<Store>?> GetStoresForUser(int userid)
     {
         DynamicParameters parameters = new DynamicParameters();

--- a/Plot/DataAccess/Interfaces/IUserContext.cs
+++ b/Plot/DataAccess/Interfaces/IUserContext.cs
@@ -26,6 +26,8 @@ public interface IUserContext
     Task<int> DeleteUserById(int userId);
     Task<int> DeleteUserFromStore(AccessModel accessModel);
     Task<IEnumerable<Store>?> GetStoresForUser(int userid);
+    Task<IEnumerable<Store>?> GetStoresNotForUser(int userid);
+
     Task<int> AddUserToStore(AccessModel accessModel);
     Task<int> UpdateAccessList(UpdateAccessList updateAccessList);
 

--- a/Plot/DataAccess/Interfaces/IUserContext.cs
+++ b/Plot/DataAccess/Interfaces/IUserContext.cs
@@ -22,13 +22,12 @@ public interface IUserContext
 {
     Task<IEnumerable<UserDTO>?> GetUsers();
     Task<UserDTO?> GetUserById(int userId);
+    Task<UserDTO?> GetUserByEmail(string userEmail);
     Task<int> UpdateUserPublicInfo(int userId, UpdatePublicInfoUser user);
     Task<int> DeleteUserById(int userId);
     Task<int> DeleteUserFromStore(AccessModel accessModel);
     Task<IEnumerable<Store>?> GetStoresForUser(int userid);
     Task<IEnumerable<Store>?> GetStoresNotForUser(int userid);
-
     Task<int> AddUserToStore(AccessModel accessModel);
     Task<int> UpdateAccessList(UpdateAccessList updateAccessList);
-
 }


### PR DESCRIPTION
1. Removes row check in updating store access so that it may update access when no store access is deleted (when the update is entirely inserting access).
2. Adds GetStoresNotForUser to handle requests for stores a user does not have access to. Puts stores as return in return Ok() for this as well as for GetStoresForUser in the User Controller.